### PR TITLE
ResolveTypesUsingAncestor attribute

### DIFF
--- a/Packages/UIForia/Src/Attributes/ResolveTypesUsingAncestor.cs
+++ b/Packages/UIForia/Src/Attributes/ResolveTypesUsingAncestor.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace UIForia.Attributes {
+    [AttributeUsage(AttributeTargets.Class, Inherited = false)]
+    public class ResolveTypesUsingAncestor : Attribute {
+        public Type ancestorType;
+
+        public ResolveTypesUsingAncestor(Type ancestorType) {
+            this.ancestorType = ancestorType;
+        }
+    }
+}

--- a/Packages/UIForia/Src/Attributes/ResolveTypesUsingAncestor.cs.meta
+++ b/Packages/UIForia/Src/Attributes/ResolveTypesUsingAncestor.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 6a9c58375d1f43f3aaa7c1030f972426
+timeCreated: 1610005442

--- a/Packages/UIForia/Tests/Data/TemplateBindings/TemplateBindingTest_ResolveTypesUsingAncestor.xml
+++ b/Packages/UIForia/Tests/Data/TemplateBindings/TemplateBindingTest_ResolveTypesUsingAncestor.xml
@@ -1,0 +1,34 @@
+<UITemplate>
+    
+    <Contents id="ancestor">
+        {Type}
+        <define:Children />
+    </Contents>
+
+    <Contents id="child">
+        {Type}
+    </Contents>
+    
+    <Contents id="grandchild">
+        {Type}
+    </Contents>
+    
+    <Contents>
+        
+        <TemplateBindingTest_ResolveTypesUsingAncestor_Ancestor id="ancestor" val="'hello'">
+            <TemplateBindingTest_ResolveTypesUsingAncestor_Child id="child"/>
+            <Div>
+                <TemplateBindingTest_ResolveTypesUsingAncestor_Grandchild id="grandchild"/>
+            </Div>
+        </TemplateBindingTest_ResolveTypesUsingAncestor_Ancestor>
+
+        <TemplateBindingTest_ResolveTypesUsingAncestor_Ancestor2 id="ancestor2" val1="'hello'" val2="list" val3="3f">
+            <TemplateBindingTest_ResolveTypesUsingAncestor_Child2 id="child2"/>
+            <Div>
+                <TemplateBindingTest_ResolveTypesUsingAncestor_Grandchild2 id="grandchild2"/>
+            </Div>
+        </TemplateBindingTest_ResolveTypesUsingAncestor_Ancestor2>
+        
+    </Contents>
+    
+</UITemplate>

--- a/Packages/UIForia/Tests/Data/TemplateBindings/TemplateBindingTest_ResolveTypesUsingAncestor.xml.meta
+++ b/Packages/UIForia/Tests/Data/TemplateBindings/TemplateBindingTest_ResolveTypesUsingAncestor.xml.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: ab545654a7ac467bbaf6980a20d9168d
+timeCreated: 1610619878

--- a/Packages/UIForia/Tests/Data/TemplateBindings/TemplateBindingTest_ResolveTypesUsingAncestorMismatch.xml
+++ b/Packages/UIForia/Tests/Data/TemplateBindings/TemplateBindingTest_ResolveTypesUsingAncestorMismatch.xml
@@ -1,0 +1,20 @@
+<UITemplate>
+    
+    <Contents id="ancestor">
+        {Type}
+        <define:Children />
+    </Contents>
+
+    <Contents id="child">
+        {Type}
+    </Contents>
+    
+    <Contents>
+        
+        <TemplateBindingTest_ResolveTypesUsingAncestor_Mismatch_Ancestor id="ancestor" val1="'hello'" val2="300f">
+            <TemplateBindingTest_ResolveTypesUsingAncestor_Mismatch_Child id="child"/>
+        </TemplateBindingTest_ResolveTypesUsingAncestor_Mismatch_Ancestor>
+       
+    </Contents>
+    
+</UITemplate>

--- a/Packages/UIForia/Tests/Data/TemplateBindings/TemplateBindingTest_ResolveTypesUsingAncestorMismatch.xml.meta
+++ b/Packages/UIForia/Tests/Data/TemplateBindings/TemplateBindingTest_ResolveTypesUsingAncestorMismatch.xml.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 9067abf323334b0c9d7b03b050ccd92d
+timeCreated: 1610622734

--- a/Packages/UIForia/Tests/Data/TemplateBindings/TemplateBindingTests.cs
+++ b/Packages/UIForia/Tests/Data/TemplateBindings/TemplateBindingTests.cs
@@ -1145,6 +1145,94 @@ namespace TemplateBinding {
             Assert.IsInstanceOf<TemplateBindingTest_ResolveGeneric_Inner1<float>>(e[2]);
         }
 
+        [Template("Data/TemplateBindings/TemplateBindingTest_ResolveTypesUsingAncestor.xml#ancestor")]
+        public class TemplateBindingTest_ResolveTypesUsingAncestor_Ancestor<T> : UIElement {
+            public T val;
+            public Type Type => val.GetType();
+        }
+        
+        [ResolveTypesUsingAncestor(typeof(TemplateBindingTest_ResolveTypesUsingAncestor_Ancestor<>))]
+        [Template("Data/TemplateBindings/TemplateBindingTest_ResolveTypesUsingAncestor.xml#child")]
+        public class TemplateBindingTest_ResolveTypesUsingAncestor_Child<T> : UIElement {
+            public T val;
+            public Type Type => val.GetType();
+        }
+        
+        [ResolveTypesUsingAncestor(typeof(TemplateBindingTest_ResolveTypesUsingAncestor_Ancestor<>))]
+        [Template("Data/TemplateBindings/TemplateBindingTest_ResolveTypesUsingAncestor.xml#grandchild")]
+        public class TemplateBindingTest_ResolveTypesUsingAncestor_Grandchild<T> : UIElement {
+            public T val;
+            public Type Type => val.GetType();
+        }
+        
+        [Template("Data/TemplateBindings/TemplateBindingTest_ResolveTypesUsingAncestor.xml#ancestor")]
+        public class TemplateBindingTest_ResolveTypesUsingAncestor_Ancestor2<Type1, Type2, Type3> : UIElement {
+            public Type1 val1;
+            public Type2 val2;
+            public Type3 val3;
+            public Type Type => val1.GetType();
+        }
+        
+        [ResolveTypesUsingAncestor(typeof(TemplateBindingTest_ResolveTypesUsingAncestor_Ancestor2<,,>))]
+        [Template("Data/TemplateBindings/TemplateBindingTest_ResolveTypesUsingAncestor.xml#child")]
+        public class TemplateBindingTest_ResolveTypesUsingAncestor_Child2<Type1, Type2, Type3> : UIElement {
+            public Type1 val1;
+            public Type2 val2;
+            public Type3 val3;
+            public Type Type => val1.GetType();
+        }
+        
+        [ResolveTypesUsingAncestor(typeof(TemplateBindingTest_ResolveTypesUsingAncestor_Ancestor2<,,>))]
+        [Template("Data/TemplateBindings/TemplateBindingTest_ResolveTypesUsingAncestor.xml#grandchild")]
+        public class TemplateBindingTest_ResolveTypesUsingAncestor_Grandchild2<Type1, Type2, Type3> : UIElement {
+            public Type1 val1;
+            public Type2 val2;
+            public Type3 val3;
+            public Type Type => val1.GetType();
+        }
+
+        [Template("Data/TemplateBindings/TemplateBindingTest_ResolveTypesUsingAncestor.xml")]
+        public class TemplateBindingTest_ResolveTypesUsingAncestor : UIElement {
+            public List<int> list;
+        }
+        
+        [Test]
+        public void ResolveTypesUsingAncestor() {
+            MockApplication app = MockApplication.Setup<TemplateBindingTest_ResolveTypesUsingAncestor>();
+            TemplateBindingTest_ResolveTypesUsingAncestor e = (TemplateBindingTest_ResolveTypesUsingAncestor) app.RootElement;
+            Assert.IsInstanceOf<TemplateBindingTest_ResolveTypesUsingAncestor_Ancestor<string>>(e.FindById("ancestor"));
+            Assert.IsInstanceOf<TemplateBindingTest_ResolveTypesUsingAncestor_Child<string>>(e.FindById("child"));
+            Assert.IsInstanceOf<TemplateBindingTest_ResolveTypesUsingAncestor_Grandchild<string>>(e.FindById("grandchild"));
+            
+            Assert.IsInstanceOf<TemplateBindingTest_ResolveTypesUsingAncestor_Ancestor2<string, List<int>, float>>(e.FindById("ancestor2"));
+            Assert.IsInstanceOf<TemplateBindingTest_ResolveTypesUsingAncestor_Child2<string, List<int>, float>>(e.FindById("child2"));
+            Assert.IsInstanceOf<TemplateBindingTest_ResolveTypesUsingAncestor_Grandchild2<string, List<int>, float>>(e.FindById("grandchild2"));
+        }
+        
+        [Template("Data/TemplateBindings/TemplateBindingTest_ResolveTypesUsingAncestorMismatch.xml#ancestor")]
+        public class TemplateBindingTest_ResolveTypesUsingAncestor_Mismatch_Ancestor<Type1, Type2> : UIElement {
+            public Type1 val1;
+            public Type2 val2;
+            public Type Type => val1.GetType();
+        }
+        
+        [ResolveTypesUsingAncestor(typeof(TemplateBindingTest_ResolveTypesUsingAncestor_Mismatch_Ancestor<,>))]
+        [Template("Data/TemplateBindings/TemplateBindingTest_ResolveTypesUsingAncestorMismatch.xml#child")]
+        public class TemplateBindingTest_ResolveTypesUsingAncestor_Mismatch_Child<T> : UIElement {
+            public T val;
+            public Type Type => val.GetType();
+        }
+        
+        [Template("Data/TemplateBindings/TemplateBindingTest_ResolveTypesUsingAncestorMismatch.xml")]
+        public class TemplateBindingTest_ResolveTypesUsingAncestor_Mismatch : UIElement {
+        }
+                
+        [Test]
+        public void ResolveTypesUsingAncestorMismatch() {
+            CompileException exception = Assert.Throws<CompileException>(() => { MockApplication.Setup<TemplateBindingTest_ResolveTypesUsingAncestor_Mismatch>(); });
+            Assert.IsTrue(exception.Message.Contains("Unable to resolve arguments using ancestor"));
+        }
+
         [Template("Data/TemplateBindings/TemplateBindingTest_SlotContext.xml#level-2")]
         public class TemplateBindingTest_ResolveSlotContext_2 : UIElement {
 


### PR DESCRIPTION
Added new attribute `ResolveTypesUsingAncestor`, that allows to resolve generic types using ancestor types.

Use case: We want to define `Table<T>`, but don't want to explicitly define types for `TableColumn<T>`. Instead we want them to be deducted from ancestor type.

This allow following layout to work

```
<Table items="items">
  <TableColumn>$items</TableColumn>
</Table>
```

## ResolveTypesUsingAncestor and type resolution using fields
The `ResolveTypesUsingAncestor` attribute overrides type resolution using fields. You must use one of the ways to resolve types, not both.