### PR TITLE
Exposing all hovered elements before "ancestor culling".

### DIFF
--- a/Packages/UIForia/Src/Systems/IInputSystem.cs
+++ b/Packages/UIForia/Src/Systems/IInputSystem.cs
@@ -11,7 +11,7 @@ namespace UIForia.Systems {
         /// <summary>
         /// Can contain destroyed elements (released to pool). Check "isDestroyed" flag before processing the element. 
         /// </summary>
-        IReadOnlyList<UIElement> ElementsThisFrame { get; }
+        IReadOnlyList<UIElement> AllElementsThisFrame { get; }
         
 #if UNITY_EDITOR
         List<UIElement> DebugElementsThisFrame { get; }

--- a/Packages/UIForia/Src/Systems/InputSystem/InputSystem.cs
+++ b/Packages/UIForia/Src/Systems/InputSystem/InputSystem.cs
@@ -347,8 +347,6 @@ namespace UIForia.Systems {
             // if dragging only attempt intersections with elements who have drag responders
             // if not dragging only attempt intersections with elements who have hover state (if mouse is present) or drag create or mouse / touch interactions
 
-            m_AllElementsThisFrame.Clear();
-            
             LightList<UIElement> queryResults = (LightList<UIElement>) m_LayoutSystem.QueryPoint(mouseState.mousePosition, LightList<UIElement>.Get());
 
             // todo -- bug!
@@ -368,6 +366,9 @@ namespace UIForia.Systems {
 
                 return b.layoutBox.traversalIndex - a.layoutBox.traversalIndex;
             });
+            
+            m_AllElementsThisFrame.Clear();
+            m_AllElementsThisFrame.AddRange(queryResults);
 
             if (!IsDragging) {
                 LightList<UIElement> ancestorElements = LightList<UIElement>.Get();
@@ -387,12 +388,9 @@ namespace UIForia.Systems {
                         }
                     }
                     
-                    m_AllElementsThisFrame.AddRange(queryResults);
                     LightList<UIElement>.Release(ref queryResults);
                     queryResults = ancestorElements;
                 }
-            } else {
-                m_AllElementsThisFrame.AddRange(queryResults);
             }
 
             bool didMouseMove = mouseState.DidMove;

--- a/Packages/UIForia/Src/Systems/InputSystem/InputSystem.cs
+++ b/Packages/UIForia/Src/Systems/InputSystem/InputSystem.cs
@@ -29,7 +29,7 @@ namespace UIForia.Systems {
 
         private List<UIElement> m_ElementsLastFrame;
         // Elements after sort and before ancestor check
-        private LightList<UIElement> m_AllElementsThisFrame;
+        private List<UIElement> m_AllElementsThisFrame;
 
         // temporary hack for the building system, this should be formalized and use ElementRef instead
         public IReadOnlyList<UIElement> AllElementsThisFrame => m_AllElementsThisFrame;
@@ -70,7 +70,7 @@ namespace UIForia.Systems {
             this.m_MouseDownElements = new LightList<UIElement>();
             this.m_ElementsThisFrame = new List<UIElement>();
             this.m_ElementsLastFrame = new List<UIElement>();
-            this.m_AllElementsThisFrame = LightList<UIElement>.Get();
+            this.m_AllElementsThisFrame = new List<UIElement>();
             this.m_EnteredElements = new List<UIElement>();
             this.m_ExitedElements = new List<UIElement>();
             this.m_ActiveElements = new List<UIElement>();
@@ -347,7 +347,8 @@ namespace UIForia.Systems {
             // if dragging only attempt intersections with elements who have drag responders
             // if not dragging only attempt intersections with elements who have hover state (if mouse is present) or drag create or mouse / touch interactions
 
-            bool releaseQueryResults = true;
+            m_AllElementsThisFrame.Clear();
+            
             LightList<UIElement> queryResults = (LightList<UIElement>) m_LayoutSystem.QueryPoint(mouseState.mousePosition, LightList<UIElement>.Get());
 
             // todo -- bug!
@@ -367,7 +368,7 @@ namespace UIForia.Systems {
 
                 return b.layoutBox.traversalIndex - a.layoutBox.traversalIndex;
             });
-            
+
             if (!IsDragging) {
                 LightList<UIElement> ancestorElements = LightList<UIElement>.Get();
 
@@ -385,16 +386,13 @@ namespace UIForia.Systems {
                             ancestorElements.Add(element);
                         }
                     }
-
-                    LightList<UIElement>.Release(ref m_AllElementsThisFrame);
-                    m_AllElementsThisFrame = queryResults;
+                    
+                    LightList<UIElement>.Release(ref queryResults);
+                    m_AllElementsThisFrame.AddRange(queryResults);
                     queryResults = ancestorElements;
                 }
             } else {
-                LightList<UIElement>.Release(ref m_AllElementsThisFrame);
-                m_AllElementsThisFrame = queryResults;
-                // Do not release query results, because this list is cached in a m_AllElementsThisFrame member field.
-                releaseQueryResults = false;
+                m_AllElementsThisFrame.AddRange(queryResults);
             }
 
             bool didMouseMove = mouseState.DidMove;
@@ -482,10 +480,6 @@ namespace UIForia.Systems {
                 if (mouseState.AnyMouseDownThisFrame) {
                     m_MouseDownElements.AddRange(m_ElementsThisFrame);
                 }
-            }
-
-            if (releaseQueryResults) {
-                LightList<UIElement>.Release(ref queryResults);    
             }
         }
 

--- a/Packages/UIForia/Src/Systems/InputSystem/InputSystem.cs
+++ b/Packages/UIForia/Src/Systems/InputSystem/InputSystem.cs
@@ -387,7 +387,7 @@ namespace UIForia.Systems {
                             ancestorElements.Add(element);
                         }
                     }
-                    
+
                     LightList<UIElement>.Release(ref queryResults);
                     queryResults = ancestorElements;
                 }
@@ -479,6 +479,8 @@ namespace UIForia.Systems {
                     m_MouseDownElements.AddRange(m_ElementsThisFrame);
                 }
             }
+
+            LightList<UIElement>.Release(ref queryResults);
         }
 
         private static bool IsParentOf(UIElement element, UIElement child) {

--- a/Packages/UIForia/Src/Systems/InputSystem/InputSystem.cs
+++ b/Packages/UIForia/Src/Systems/InputSystem/InputSystem.cs
@@ -387,8 +387,8 @@ namespace UIForia.Systems {
                         }
                     }
                     
-                    LightList<UIElement>.Release(ref queryResults);
                     m_AllElementsThisFrame.AddRange(queryResults);
+                    LightList<UIElement>.Release(ref queryResults);
                     queryResults = ancestorElements;
                 }
             } else {


### PR DESCRIPTION
Exposing all hovered elements before "ancestor culling", so that Client code can use all hovered elements (Unfiltered).